### PR TITLE
GameDB: Correct name for SLPS-25125

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -37658,7 +37658,7 @@ SLPS-25124:
   name: "G-Breaker 2 - Doumei no Hangeki"
   region: "NTSC-J"
 SLPS-25125:
-  name: "Iris [Limited Edition]"
+  name: "Jitsumei Jikkyou Keiba Dream Classic 2002"
   region: "NTSC-J"
 SLPS-25127:
   name: "Air"


### PR DESCRIPTION


### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
SLPS-25125 was labelled Iris [Limited Edition], while it should be Jitsumei Jikkyou Keiba Dream Classic 2002

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
